### PR TITLE
Refactor analysis scripts using visitor pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
     "jinja2"
 ]
 requires-python = ">= 3.8"
+
+[project.optional-dependencies]
+analysis = ["xlsxwriter", "matplotlib", "openpyxl"]

--- a/src/analysis/analyze-token-usage.py
+++ b/src/analysis/analyze-token-usage.py
@@ -8,6 +8,35 @@ from pathlib import Path
 from rich.console import Console
 from rich.table import Table
 
+from visitor import JSONLogWalker
+
+class TokenUsageVisitor:
+    def __init__(self):
+        self.results = {}
+
+    def __call__(self, j):
+        if 'costs' in j:
+            event = j['event']
+            if event in self.results:
+                assert self.results[event]['model_name'] == j['costs']['model_name']
+                self.results[event]['duration'] += j['duration']
+                self.results[event]['total'] += j['costs']['token_usage']['total_tokens']
+                self.results[event]['prompt'] += j['costs']['token_usage']['prompt_tokens']
+                self.results[event]['completions'] += j['costs']['token_usage']['completion_tokens']
+                self.results[event]['reasoning'] += j['costs']['token_usage']['completion_tokens_details']['reasoning_tokens']
+                self.results[event]['cached'] += j['costs']['token_usage']['prompt_tokens_details']['cached_tokens']
+            else:
+                self.results[event] = {
+                    'duration': j['duration'],
+                    'model_name': j['costs']['model_name'],
+                    'event': event,
+                    'total': j['costs']['token_usage']['total_tokens'],
+                    'prompt': j['costs']['token_usage']['prompt_tokens'],
+                    'completions': j['costs']['token_usage']['completion_tokens'],
+                    'reasoning': j['costs']['token_usage']['completion_tokens_details']['reasoning_tokens'],
+                    'cached': j['costs']['token_usage']['prompt_tokens_details']['cached_tokens'],
+                }
+
 def analyzse_file(filename):
 
     results = {}

--- a/src/analysis/visitor.py
+++ b/src/analysis/visitor.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+
+import json
+
+class JSONLogWalker:
+    """
+    Simple JSON log walker that iterates through each JSON line
+    in the provided file and dispatches it to registered handlers.
+    """
+    def __init__(self, path):
+        self.path = path
+        self.handlers = []
+
+    def register(self, handler):
+        """Register a handler function that takes a JSON object."""
+        self.handlers.append(handler)
+
+    def walk(self):
+        """
+        Iterate through each line in the log file, parse it as JSON,
+        and dispatch to all registered handlers.
+        """
+        with open(self.path, 'r') as f:
+            for line in f:
+                data = json.loads(line)
+                for handler in self.handlers:
+                    handler(data)


### PR DESCRIPTION
This PR addresses #2 by refactoring the ad-hoc analysis scripts in src/analysis.

- Introduce a JSONLogWalker to centralize JSON log parsing and handler dispatch.
- Refactor the token usage analysis to use the visitor pattern.
- Add optional dependencies group analysis in pyproject.toml for analysis tools (xlsxwriter, matplotlib, openpyxl).

This lays the groundwork for converting other analysis scripts to a visitor-based design.